### PR TITLE
@ack for socket.io acknowledgements 

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -396,9 +396,10 @@ zappa.app = (func) ->
     for name, h of ws_handlers
       do (name, h) ->
         if name isnt 'connection' and name isnt 'disconnect'
-          socket.on name, (data) ->
+          socket.on name, (data, ack) ->
             ctx = build_ctx()
             ctx.data = data
+            ctx.ack = ack
             switch app.settings['databag']
               when 'this' then h.apply(data, [ctx])
               when 'param' then h.apply(ctx, [data])


### PR DESCRIPTION
There's no way, as far as I can tell, to acknowledge messages in socket.io.

This fix adds @ack to the scope of @on.
