### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/crashcourse.md
+++ b/docs/crashcourse.md
@@ -266,7 +266,7 @@ On a step further, you have `@client`, which gives you access to a matching clie
       html ->
         head ->
           title 'Client-side zappa'
-          script src: '/zappa/Zappa.js'
+          script src: '/zappa/zappa.js'
           script src: '/index.js'
         body ''
 


### PR DESCRIPTION
Zappa.js should be zappa.js
