### PR TITLE
Pass request, response, next as parameters to middleware to support non-zappajs middleware

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -426,7 +426,7 @@ zappa.app = (func,options={}) ->
           ctx.data = {}
           copy_data_to ctx.data, [req.query, req.params, req.body]
 
-        f.apply ctx
+        f.apply ctx, [req, res, next]
 
     if typeof r.handler is 'string'
       app[r.verb] r.path, r.middleware, (req, res) ->


### PR DESCRIPTION
As is, the following will fail, because basicAuth (as most other middleware) expects the arguments (req, res, next) instead of having them being passed in the context.

```
require('zappajs') ->
  connect = require 'connect'

  auth = -> (user, pass) ->
    user == 'hello' and pass == 'world'

  @get '/', -> 'welcome'
  @get '/auth', connect.basicAuth(auth), -> 'authenticated'
```

Currently you'd have to wrap the basicAuth middleware to pass in the context

```
require('zappajs') ->
  connect = require 'connect'

  auth = ->
    fn = connect.basicAuth (user, pass) ->
      user == 'hello' and pass == 'world'
    fn @request, @response, @next

  @get '/', -> 'welcome'
  @get '/auth', auth, -> 'authenticated'
```
