### PR TITLE
options for express.static

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -272,8 +272,13 @@ zappa.app = (func,options={}) ->
   context.use = ->
     zappa_middleware =
       # Connect `static` middlewate uses fs.stat().
-      static: (p = path.join(real_root, '/public')) ->
-        express.static(p)
+      static: (options) ->
+        if typeof options is 'string'
+          options = path: options
+        options ?= {}
+        p = options.path ? path.join(real_root, '/public')
+        express.static(p, options)
+        return
       staticGzip: (options) ->
         if typeof options is 'string'
           options = path: options


### PR DESCRIPTION
I went to set maxAge for some static assets and realized we're only accepting the path.  

Other options include (from connect.static - )...
https://github.com/senchalabs/connect/blob/master/lib/middleware/static.js
- Options:
  *
-    - `maxAge`     Browser cache maxAge in milliseconds. defaults to 0
-    - `hidden`     Allow transfer of hidden files. defaults to false
-    - `redirect`   Redirect to trailing "/" when the pathname is a dir. defaults to true
