### PR TITLE
Allow middleware when routing using key-value syntax

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -132,6 +132,9 @@ Ex.:
         @next "Failed to load user #{@params.id}"
 
     @get '/', load_user, -> 'hi'
+    
+    # Or using alternate syntax
+    @get '/': [load_user, -> 'hi']
 
 You can pass middleware arrays using Coffee-Script's `...` splats:
 
@@ -144,6 +147,9 @@ Or as plain arrays, as Express allows:
     common = [auth, load_user, apply_policy]
 
     @get '/', common, -> 'hi'
+    
+    # Or using alternate syntax
+    @get '/': [common, -> 'hi']
 
 ### @on
 

--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -184,7 +184,16 @@ zappa.app = ->
             handler: args[arity-1]
         else
           for k, v of arguments[0]
-            route verb: verb, path: k, handler: v
+            # Apply middleware if value is array
+            if v instanceof Array
+              route
+                verb: verb
+                path: k
+                middleware: flatten v[0...v.length-1]
+                handler: v[v.length-1]
+                
+            else
+              route verb: verb, path: k, handler: v
         return
 
   context.client = (obj) ->

--- a/tests/routes.coffee
+++ b/tests/routes.coffee
@@ -85,12 +85,21 @@ port = 15000
       @get '/string/:id', load_user, -> 'string'
       @get '/return/:id', load_user, -> 'return'
       @get '/send/:id', load_user, -> @send 'send'
+      
+      @get '/string1/:id': [load_user, -> 'string']
+      @get '/return1/:id': [load_user, -> 'return']
+      @get '/send1/:id': [load_user, -> @send 'send']
 
     c = t.client(zapp.server)
     c.get '/string/bob', (err, res) -> t.equal 1, res.body, 'string'
     c.get '/return/bob', (err, res) -> t.equal 2, res.body, 'return'
     c.get '/send/bob', (err, res) -> t.equal 3, res.body, 'send'
     c.get '/send/bar', (err, res) -> t.equal 3, res.body, 'Failed to load user bar'
+    
+    c.get '/string1/bob', (err, res) -> t.equal 1, res.body, 'string'
+    c.get '/return1/bob', (err, res) -> t.equal 2, res.body, 'return'
+    c.get '/send1/bob', (err, res) -> t.equal 3, res.body, 'send'
+    c.get '/send1/bar', (err, res) -> t.equal 3, res.body, 'Failed to load user bar'
 
   methods: (t) ->
     t.expect [1..6]...


### PR DESCRIPTION
Added support for using arrays as values when using the object notation for routing. All tests passing.

Example:

``` coffeescript
require('zappajs') ->
    @get '/': [ authenticate, ->
      @render 'index'
    ]
```
