### PR TITLE
Express 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "body-parser": "^1.3.0",
     "response-time": "^2.0.0",
     "cookie-parser": "^1.1.0",
+    "csurf":         "^1.4.0",
+    "connect-redis": "^2.0.0",
     "method-override": "^2.0.0",
     "express-session": "^1.2.1",
     "serve-static": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zappajs",
   "description": "CoffeeScript minimalist interface to express, socket.io and others",
-  "version": "0.4.22",
+  "version": "0.5.0",
   "author": "Stephane Alnet <stephane@shimaore.net>",
   "homepage": "http://zappajs.github.com/zappajs/",
   "repository": {
@@ -21,10 +21,13 @@
     "cookie-parser": "^1.1.0",
     "csurf":         "^1.4.0",
     "connect-redis": "^2.0.0",
+    "connect-mongo": "^0.4.1",
     "method-override": "^2.0.0",
     "express-session": "^1.2.1",
     "serve-static": "^1.2.0",
+    "morgan": "^1.2.2",
     "serve-index": "^1.1.0"
+
   },
   "devDependencies": {
     "coffee-script": "1.7.1",

--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -3,7 +3,7 @@
 # integrating [express](http://expressjs.com), [socket.io](http://socket.io)
 # and other best-of-breed libraries.
 
-zappa = version: '0.49.0'
+zappa = version: '0.5.0'
 
 codename = 'You can\'t do that on stage anymore'
 


### PR DESCRIPTION
These are the changes which were required to get my application working on Express version 4 with zappa. Creating a pull request, and we can hopefully release this as a beta. 

I wrote a wiki article on moving from version 0.4.x (express 3.x) to version 0.5.x (express 4.x). I'll create a pull request for the wiki as well.

The wiki page for the upgrade is at https://github.com/fgruner/zappajs/wiki/Migrating-from-Version-0.4.x-(express-3.x)-to-Version-0.5.x-(express-4.x)
I don't know how to create a pull request for the wikipage. If someone can tell me that, then I'll create a pull request for that as well.
