### PR TITLE
Socketio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/*.js
 _site
 vendor
 examples/public/bin
+/.project

--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@ Zappa is a [CoffeeScript](http://coffeescript.org)-optimized interface to [Expre
 ## Synopsis
 
 ```coffee
-require('zappajs') ->
+socketio = require 'socket.io'
+
+port = process.env.PORT || 3000
+
+require('zappajs') {port: port, socketio: socketio}, ->
 
   # Server-side
 
   @get '/': ->
     @render 'index',
       title: 'Zappa!'
-      scripts: '/zappa/Zappa-simple.js /index.js /client.js'
+      scripts: '/zappa/jquery.js /socket.io/socket.io.js /zappa/sammy.js /zappa/zappa.js /index.js /client.js'
       stylesheet: '/index.css'
 
   @view index: ->

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -61,7 +61,11 @@ skeleton = ->
 
     context.share = (channel,socket,cb) ->
       zappa_prefix = settings.zappa_prefix
-      $.getJSON zappa_prefix+"/socket/#{channel}/#{socket.socket.sessionid}", cb
+      if (socket.socket != null)
+        	sessionid = socket.socket.sessionid
+        if (socket.io != null)
+        	sessionid = socket.io.engine.id
+        return $.getJSON(zappa_prefix + ("/socket/" + channel + "/" + sessionid), cb);
 
     route = (r) ->
       ctx = {app}

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -62,10 +62,10 @@ skeleton = ->
     context.share = (channel,socket,cb) ->
       zappa_prefix = settings.zappa_prefix
       if (socket.socket != null)
-        	sessionid = socket.socket.sessionid
-        if (socket.io != null)
-        	sessionid = socket.io.engine.id
-        return $.getJSON(zappa_prefix + ("/socket/" + channel + "/" + sessionid), cb);
+        sessionid = socket.socket.sessionid
+      if (socket.io != null)
+        sessionid = socket.io.engine.id
+      return $.getJSON(zappa_prefix + ("/socket/" + channel + "/" + sessionid), cb);
 
     route = (r) ->
       ctx = {app}

--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -152,7 +152,8 @@ zappa.app = ->
   if options.disable_io
     io = null
   else
-    io = context.io = socketio.listen context.server, options.io ? {}
+    options.socketio ?= socketio
+    io = context.io = options.socketio.listen context.server, options.io ? {}
 
   # Reference to the zappa client, the value will be set later.
   client = null
@@ -726,6 +727,7 @@ zappa.run = ->
             when 'port' then port = v
             when 'disable_io' then options.disable_io = v
             when 'https' then options.https = v
+            when 'socketio' then options.socketio = v
 
   zapp = zappa.app(root_function,options)
   app = zapp.app


### PR DESCRIPTION
- add options.socketio to allow importing socket.io other than default v0.9
- update readme to download socketio client code from /socket.io/socket.io.js instead of default v0.9
