### PR TITLE
fix frontend load balance uri prefix, resulting in incorrect path of sock...

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -69,7 +69,7 @@ skeleton = ->
       # socket.socket.sessionid is the old (0.9) Socket.IO sessionid.
       sessionid = socket.io?.engine.id ? socket.socket?.sessionid
       if sessionid?
-        $.getJSON "#{zappa_prefix}/socket/#{channel}/#{sessionid}", cb
+        $.getJSON ".#{zappa_prefix}/socket/#{channel}/#{sessionid}", cb
 
     route = (r) ->
       ctx = {app}


### PR DESCRIPTION
when load balance http://xxx.com/server1/{room_id} dispatch to LAN http://192.168.0.1/ have a issue for /zappa/socket.io URL error
