### PR TITLE
Flag on path alone when using IPC socket

### DIFF
--- a/src/zappa.coffee.md
+++ b/src/zappa.coffee.md
@@ -859,10 +859,9 @@ Takes a function and runs it as a zappa app. Optionally accepts a port number, a
       zapp = zappa.app(root_function,options)
       {server,app} = zapp
 
-      is_ipc = typeof ipc_path is 'string'
-
       server.on 'listening', ->
-        channel = if is_ipc then ipc_path else do (addr = server.address()) -> "#{addr.address}:#{addr.port}"
+        addr = server.address()
+        channel = if typeof addr is 'string' then addr else addr.address + ':' + addr.port
         debug """
           Express server listening on #{channel} in #{app.settings.env} mode.
           Zappa #{zappa.version} orchestrating the show.
@@ -870,7 +869,7 @@ Takes a function and runs it as a zappa app. Optionally accepts a port number, a
         """
 
       switch
-        when is_ipc
+        when ipc_path
           server.listen ipc_path
         when host
           server.listen port, host


### PR DESCRIPTION
This is a tiny optimisation (in terms of reading clarity) that I meant to push before #117 was merged and closed. Feel free to close or merge but I wanted to bring it up just for sake of completeness. :)

It gets rid of `is_ipc` since predicating on `ipc_path` remained in one location only in the end.

Thanks!
