### PR TITLE
add support for cluster

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -114,6 +114,7 @@ You can also pass the parameters in the `options` object; they are described in 
 * `host`: the hostname or IP address for the web server.
 * `path`: IPC path; if present, ZappaJS will start an [IPC server](https://nodejs.org/api/net.html#net_server_listen_path_backlog_callback) instead of a TCP/IP server.
 * `ready`: this function is called once the server is ready to accept requests.
+* `server`: if the `server` option is set to the string `cluster`, ZappaJS will use `throng` to start and manage a Node.js cluster. In this case the function will not return anything useful; use the `ready` option to handle server startup.
 
 The default port and host may also be specified as part of the environment variables, using `ZAPPA_PORT` and `ZAPPA_HOST`, respectively.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "socket.io": "^1.7.3",
     "socket.io-client": "^1.7.3",
     "teacup": "^2.0.0",
+    "throng": "^4.0.0",
     "uglify-js": "^2.8.4"
   },
   "devDependencies": {
@@ -73,7 +74,7 @@
   ],
   "scripts": {
     "pretest": "npm install -d",
-    "test": "coffee tests/index.coffee && mocha --compilers coffee.md:coffee-script/register mocha/tests/",
+    "test": "coffee tests/index.coffee && mocha --compilers coffee.md:coffee-script/register mocha/tests/ && coffee tests/cluster.coffee.md",
     "prepublish": "coffee -o lib -c -M src/*.coffee.md",
     "docs": "docco src/*.coffee.md",
     "clean": "rm lib/*.js lib/*.js.map benchmarks/out/*.dat benchmarks/out/*.out tests/*.js",

--- a/tests/cluster.coffee.md
+++ b/tests/cluster.coffee.md
@@ -1,0 +1,30 @@
+    zappa = require '../src/zappa'
+    port = 15804
+
+    seem = require 'seem'
+    request = require 'superagent'
+    assert = require 'assert'
+
+    sleep = (timeout) ->
+      new Promise (resolve) ->
+        setTimeout resolve, timeout
+
+    do ->
+
+      ready = seem ->
+
+        yield sleep 1000
+
+        {text} = yield request.get "http://localhost:#{port}/"
+        assert text is 'cluster'
+
+        {text} = yield request.get "http://127.0.0.1:#{port}/"
+        assert text is 'cluster'
+
+        console.log 'Cluster test OK'
+
+        process.exit(0)
+
+      zappa {ready, server:'cluster', port}, ->
+        @get '/': 'cluster'
+


### PR DESCRIPTION
Add support for cluster.

The main issue is that socket.io clients need to be directed to the same socket.io handler (apparently the socket.io handshake might use multiple TCP connections).