### PR TITLE
cleanup before IPC run

### DIFF
--- a/tests/run.coffee
+++ b/tests/run.coffee
@@ -63,6 +63,8 @@ port = 15800
   'path (IPC)': (t) ->
     t.expect 'ipc'
 
+    (require 'fs').unlink '/tmp/zappa_ipc', -> true
+
     zapp = zappa path:'/tmp/zappa_ipc', ->
       @get '/': 'ipc'
 


### PR DESCRIPTION
When testing interactively, if the test suite crashes the IPC socket might linger behind.